### PR TITLE
curate dsh-cad-review

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -51,6 +51,12 @@
       "note": "DeepSeek Harness 精选插件清单（awesome list）",
       "repo": "awesome-dsh-plugin/awesome-dsh-plugin"
     },
+    "dsh-cad-review": {
+      "category": "devtools",
+      "note": "离线检查 ASCII DXF：输出带源文件哈希的实体、图层、坐标与确定性制图规则证据",
+      "repo": "dongsheng123132/dsh-cad-review",
+      "keep": true
+    },
     "dsh-ads": {
       "category": "skin",
       "note": "2005 年中文站点风格的复古广告插件：侧栏广告 / 对话内信息流 / 角落弹窗",


### PR DESCRIPTION
## What changed

Adds `dongsheng123132/dsh-cad-review` to the manual curation source as a `devtools` entry with `keep: true`.

## Why

The plugin is a real DSH bundle for offline ASCII DXF inspection. It reports source-hashed entity, layer, coordinate, and deterministic drawing-rule evidence, but its current star count is below the automatic curation threshold.

## Verification

- Immutable source and smoke commands: https://github.com/dongsheng123132/dsh-cad-review/tree/69b808ecceb7eb98e4acb7d036a5ce8706fb43d9
- Clean GitHub Actions run: https://github.com/dongsheng123132/dsh-cad-review/actions/runs/31748669218
- `data/curated.json` parses successfully; `git diff --check` passes