### PR TITLE
feat: register dsh-feishucard (Feishu channel plugin)

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1,6 +1,11 @@
 {
   "min_stars": 3,
   "overrides": {
+    "dsh-feishucard": {
+      "category": "channel",
+      "note": "DSH 飞书桥（自研非 fork）：官方 SDK 长连接 + 流式回复卡片（过程话语内联/工具折叠面板/状态符号/限流退避熔断兜底），每聊天独立会话 + live 复用保上下文，npm dsh-feishucard",
+      "repo": "cmfok/dsh-feishucard"
+    },
     "modlens": {
       "category": "vision",
       "note": "DSH 首个视觉插件：纯文本模型的视觉桥梁",


### PR DESCRIPTION
Register [dsh-feishucard](https://github.com/cmfok/dsh-feishucard) in curated.json (category: channel).

Self-developed (not a fork) DSH <-> Feishu (Lark) bridge:
- official-SDK long connection, streaming reply card
- dedicated per-chat sessions, live-session reuse preserves context
- npm dsh-feishucard@0.1.0, repo has \dsh-plugin\ topic

Also auto-synced via the 8h topic scan.