### PR TITLE
docs: 登记 dsh-theme-plugin & dsh-opencodego-usage

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1225,6 +1225,18 @@
       "category": "agent",
       "note": "Falsify CLI 适配器",
       "repo": "shi275773124/falsify-dsh"
+    },
+    "dsh-theme-plugin": {
+      "category": "skin",
+      "note": "DSH Web GUI 主题工作室：5 套内置预设（codex-warm/nord/solarized/graphite/stock）+ 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化",
+      "repo": "BeiZi6/dsh-theme-plugin",
+      "keep": true
+    },
+    "dsh-opencodego-usage": {
+      "category": "webui",
+      "note": "OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动/周/月三窗口用量与重置时间），每 30 秒自动刷新，Key 自动读取 DSH 凭据",
+      "repo": "BeiZi6/dsh-opencodego-usage",
+      "keep": true
     }
   },
   "manual": [


### PR DESCRIPTION
按 [CONTRIBUTING](https://github.com/like-study1/Oh-My-DSH/blob/main/CONTRIBUTING.md#2-通过-issue--pr-登记) 第 2 条，在 `data/curated.json` 的 `overrides` 中登记两个插件（均带 `keep: true`，因为当前都是 2★，低于 `min_stars: 3` 自动初筛门槛；两仓库均已打 `dsh-plugin` topic、公开、未归档）：

- `dsh-theme-plugin` → category `skin` — DSH Web GUI 主题工作室：5 套内置预设（codex-warm/nord/solarized/graphite/stock）+ 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），经官方 `ctx.theme.overrideTokens` 即时热切换、localStorage 持久化，纯官方接缝（`webServer.tapIndex`）。MIT，Node >= 22.19，`dsh.bundle` 清单。
- `dsh-opencodego-usage` → category `webui` — OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动≈5h/周/月三窗口用量与重置时间），每 30 秒自动刷新；Key 自动读取 DSH 凭据（opencode-go 提供商）也可手动覆盖，只发送到官方 OpenCodeGo 用量接口。MIT，Node >= 22.19，`dsh.bundle` 清单。

安装：`dsh plugin --profile web add github:BeiZi6/dsh-theme-plugin` / `dsh plugin --profile web add github:BeiZi6/dsh-opencodego-usage`。
