### PR TITLE
curate: 收录 dsh-quota-status（DeepSeek/Kimi 配额卡片）

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1,6 +1,12 @@
 {
   "min_stars": 3,
   "overrides": {
+    "dsh-quota-status": {
+      "category": "webui",
+      "note": "极简配额卡片：DeepSeek 余额四档变色 + 峰谷电价徽标，Kimi 套餐周限/5h 窗口进度条与重置倒计时；中英双语，loopback-only RPC 不出 Key",
+      "repo": "ruby1304/dsh-quota-status",
+      "keep": true
+    },
     "dsh-ui-font": {
       "category": "skin",
       "note": "DSH 字体插件：正文字体/代码字体/显示比例/行高/字体浏览器，中文字形标记，设置一键生效",


### PR DESCRIPTION
按 CONTRIBUTING 的人工收录路径，在 `data/curated.json` 的 overrides 中登记 [ruby1304/dsh-quota-status](https://github.com/ruby1304/dsh-quota-status)（仅 +6 行，未触碰自动生成文件）。

**插件简介**：DSH Web 极简配额卡片——DeepSeek API 余额四档变色 + 峰谷电价徽标（2026-08-17 新峰谷规则），Kimi For Coding 套餐周限/5h 窗口进度条与实时重置倒计时；中英双语跟随界面语言，loopback-only Connection RPC，API Key 不出宿主进程。

- 分类：`webui`（Web UI 增强）
- npm 可安装：[`dsh-quota-status`](https://www.npmjs.com/package/dsh-quota-status)，`dsh plugin --profile web add dsh-quota-status`
- MIT 许可、public 未归档、含 21 项单元测试与双语 README
- 仓库已加 `dsh-plugin` topic，自动同步亦可初筛；`keep: true` 仅为在新仓库 star 数未达门槛期间确保收录

已自行核验审核标准：仓库公开、描述一句话可说清、无权限/网络/系统级风险操作（只读查询官方余额/用量接口）。