### PR TITLE
feat: 登记 wz-heng/dsh-feishu-bridge（飞书/Lark channel 桥）

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1,6 +1,12 @@
 {
   "min_stars": 3,
   "overrides": {
+    "dsh-feishu-bridge": {
+      "category": "channel",
+      "note": "安全边界优先的飞书/Lark channel 桥：fail-closed 白名单、webhook 签名/重放校验、远程 bash 审批闸门（超时即拒），ws/webhook 双通道",
+      "repo": "wz-heng/dsh-feishu-bridge",
+      "keep": true
+    },
     "dsh-ui-font": {
       "category": "skin",
       "note": "DSH 字体插件：正文字体/代码字体/显示比例/行高/字体浏览器，中文字形标记，设置一键生效",


### PR DESCRIPTION
按 CONTRIBUTING 的 PR 方式登记 [wz-heng/dsh-feishu-bridge](https://github.com/wz-heng/dsh-feishu-bridge)。

- 仓库 08-14 发布时即带 `dsh-plugin` topic，但未被自动同步收录——猜测是发布头两天 star 尚未过 `min_stars: 3` 门槛、快照又未回补；现为 ★5，按文档加了 `keep: true`，如你们希望走自然初筛可去掉
- 定位：安全边界优先的飞书/Lark channel 桥（fail-closed 白名单、webhook 签名/时间戳/重放校验、一次性卡片 nonce、远程 bash 审批闸门）
- public、未归档、MIT、CI + 每日 SDK 金丝雀，Python 182 + Node 64 测试
- 已对文件的 \r\r\n 行尾保持原样，仅插入 6 行

分类给的 `channel`，note 一句话中文，如有格式偏差请直接改。