### PR TITLE
Add dsh-skill-cockpit to curated list

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1,6 +1,12 @@
 {
   "min_stars": 3,
-  "overrides": {
+  "overrides": {
+    "dsh-skill-cockpit": {
+      "category": "devtools",
+      "note": "技能驾驶舱：全量技能概览、中文备注、搜索、启停、批量导入、试射评分、使用统计、中英双语、批量管理",
+      "repo": "Itailang2333/dsh-skill-cockpit",
+      "keep": true
+    },
     "dsh-ui-font": {
       "category": "skin",
       "note": "DSH 字体插件：正文字体/代码字体/显示比例/行高/字体浏览器，中文字形标记，设置一键生效",


### PR DESCRIPTION
Add [dsh-skill-cockpit](https://github.com/Itailang2333/dsh-skill-cockpit) to data/curated.json (devtools category, keep: true).

技能驾驶舱：全量技能概览、中文备注、搜索、启停、批量导入、试射评分、使用统计、中英双语界面、批量管理。