### PR TITLE
docs: 登记 dsh-library

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -1357,6 +1357,12 @@
       "note": "11 个可共享的工作流技能包：覆盖常用 Agent 工作流场景",
       "repo": "jeremy9682/dsh-skill-pack",
       "keep": true
+    },
+    "dsh-library": {
+      "category": "data",
+      "note": "本地优先文档知识库：library_add/remove/list 与语义+关键词混合检索，引用校验与诊断，SQLite 索引 + 本地嵌入，零模型下载",
+      "repo": "PerryLink/dsh-library",
+      "keep": true
     }
   },
   "manual": [


### PR DESCRIPTION
﻿登记插件 dsh-library（本地优先文档知识库）。

- 仓库：https://github.com/PerryLink/dsh-library
- 公开、已打 dsh-plugin topic、声明 dsh.bundle manifest、npm 已发布（dsh-library@0.1.4）。
- 该插件当前 Star 数低于目录 min_stars 初筛门槛，故按 CONTRIBUTING 的「通过 Issue / PR 登记」方式，在 data/curated.json 的 overrides 中登记一条并 keep: true 强制收录。
- 一句话简介：本地优先文档知识库，library_add/remove/list 与语义+关键词混合检索、引用校验与诊断，SQLite 索引 + 本地嵌入，零模型下载。
