### PR TITLE
chore: curate three community issue submissions

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -418,6 +418,12 @@
       "note": "深链：?session=/?workspace= 直接打开指定项目对话",
       "repo": "qyw233/dsh-deeplink"
     },
+    "dsh-deepread": {
+      "repo": "xiehuan123/dsh-deepread",
+      "category": "agent",
+      "note": "证据优先精读插件：图书/文章/PDF/文档集的观点—证据报告、知识地图与回忆问题，含 Host 工具与可选 Web 阅读面板",
+      "keep": true
+    },
     "dsh-design": {
       "category": "agent",
       "note": "DSH 原生 Web/UI 设计 Agent bundle",
@@ -427,6 +433,12 @@
       "category": "devtools",
       "note": "社区维护的非官方桌面客户端：自动复用本机实例、智能连接、托盘常驻",
       "repo": "bruc3van/dsh-desktop"
+    },
+    "dsh-desktop-pet": {
+      "repo": "FenyxHuang/dsh-desktop-pet",
+      "category": "webui",
+      "note": "鲸鱼桌宠：实时反应 agent 状态（思考/工作/出错），API 余额渲染为圆形海平面，支持点击互动与拖拽",
+      "keep": true
     },
     "dsh-diff-viewer": {
       "category": "webui",
@@ -693,6 +705,12 @@
       "category": "agent",
       "note": "Nowledge Mem™ 集成",
       "repo": "dsh-external/dsh-nowledge-mem"
+    },
+    "dsh-nuke-plugin": {
+      "repo": "beijingwahw/dsh-nuke-plugin",
+      "category": "devtools",
+      "note": "事务化强力卸载引擎：validate/preview/execute/undo 四段式 + Saga 回滚、WAL 崩溃自恢复与 hash chain 审计链",
+      "keep": true
     },
     "dsh-oauth-mcp-client": {
       "category": "agent",


### PR DESCRIPTION
## 本次维护

收录 3 个已完成资格核验的社区申请：

- `xiehuan123/dsh-deepread`，Agent 能力
- `FenyxHuang/dsh-desktop-pet`，Web UI 增强
- `beijingwahw/dsh-nuke-plugin`，开发工具

三项均已核验：公开、未归档、非分叉、带 `dsh-plugin` topic，并在配置中使用 `keep: true`。

合并后由既有四小时维护工作流自动刷新 `snapshot.json`、`plugins.json`、`PLUGINS.md`、README、站点和 CHANGELOG。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only curation updates with no application logic or security-sensitive code paths touched.
> 
> **Overview**
> Adds **three** new entries to `data/curated.json` for community plugins that passed eligibility checks (public, non-fork, `dsh-plugin` topic, etc.), each with **`keep: true`** so they stay in the catalog regardless of star thresholds.
> 
> **`dsh-deepread`** (`xiehuan123/dsh-deepread`, agent): evidence-first deep reading for books, articles, PDFs, and document sets. **`dsh-desktop-pet`** (`FenyxHuang/dsh-desktop-pet`, webui): whale desktop pet that reflects agent state and API balance. **`dsh-nuke-plugin`** (`beijingwahw/dsh-nuke-plugin`, devtools): transactional plugin uninstall with preview, undo, and audit.
> 
> No runtime code changes—only the manual curation file. Existing maintenance workflows are expected to refresh `snapshot.json`, `plugins.json`, `PLUGINS.md`, README, site, and CHANGELOG after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d9a45b8143b1cae484316f4d2f90aaa55bf79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->